### PR TITLE
Terraform Validate

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,12 @@
+provider "aws" {
+  region = "us-east-2"
+}
+
+resource "aws_instance" "example" {
+  ami = "ami-0c55b159cbfafe1f0"
+
+  tags = {
+    Name        = "My Instance"
+    Description = "Example"
+  }
+}


### PR DESCRIPTION
This PR creates a `main.tf` file that fails the `terraform validate` step of the GitHub actions run on newly submitted pull-requests. The action should post back a comment here with the details of the failure.